### PR TITLE
Area line charts and slider tweaks

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -166,8 +166,7 @@ function brushended() {
 
 	updateMarkersBySlider(extent2[0]);
 
-	console.log(brush.extent())
-	console.log(extent2)
+	console.log(extent2);
 }
 
 

--- a/static/script.js
+++ b/static/script.js
@@ -81,7 +81,7 @@ svg_overlay.append("rect")
 var svg = d3.select(map.getPanes().overlayPane).append("svg");
 var g = svg.append("g").attr("class", "leaflet-zoom-hide");
 
-
+//slider
 var brush
 var timeFormat = d3.time.format('%j');
 
@@ -126,6 +126,7 @@ function makeSlider(){
 
 	svg_slider.append("g")
 	    .attr("class", "x axis")
+			.on("click", function(){svg_slider.select(".brush").call(brush.extent([timeFormat.parse('0'), timeFormat.parse('364')])); extent2 = [0,52]; console.log(extent2);	updateMarkersBySlider(extent2[0]);})
 	    .attr("transform", "translate(0," + height + ")")
 	    .call(d3.svg.axis()
 	      .scale(x)
@@ -133,9 +134,9 @@ function makeSlider(){
 	      .ticks(d3.time.months)
 				.tickFormat(d3.time.format("%B"))
 	      .tickPadding(0))
-	  .selectAll("text")
-	    .attr("x", 6)
-	    .style("text-anchor", null);
+		  .selectAll("text")
+		    .attr("x", 6)
+		    .style("text-anchor", null);
 
 	var gBrush = svg_slider.append("g")
 	    .attr("class", "brush")
@@ -165,12 +166,11 @@ function brushended() {
 
 	updateMarkersBySlider(extent2[0]);
 
+	console.log(brush.extent())
 	console.log(extent2)
 }
 
-$(window).on('resize', function(){
-	makeSlider();
-})
+
 
 var semanticActive = false; //toggle to active semantic UI walkthrough
 

--- a/static/script.js
+++ b/static/script.js
@@ -28,7 +28,7 @@ var topLeft = [0,0], bottomRight = [0,0];
 // helper function to retrieve query string
 // function getParameterByName(name, url) {
 //     if (!url) url = window.location.href;
-//     url = url.toLowerCase(); // This is just to avoid case sensitiveness  
+//     url = url.toLowerCase(); // This is just to avoid case sensitiveness
 //     name = name.replace(/[\[\]]/g, "\\$&");
 //     var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
 //         results = regex.exec(url);
@@ -167,10 +167,11 @@ function brushended() {
 
 	var extent2 = (extent1.map(function (d) {return Math.floor(weekIndexFormat(d)/7+1)}));
 
-	updateMarkersBySlider(extent2[0]);
+	weekIndex = extent2[0];
+	updateMarkers();
 
 	console.log(extent2[0])
-	console.log(extent2[1])
+	console.log(weekIndex)
 }
 
 
@@ -257,13 +258,6 @@ function updateMarkers(duration){
 	}
 
 }
-
-//adjusts markers by slider
-function updateMarkersBySlider(week){
-	// document.querySelector('#weekSelected').value = week
-	weekIndex = week
-	updateMarkers();
-};
 
 //adjusts visibility of semantic interface
 function toggleSemantic(){
@@ -470,6 +464,3 @@ $('#semantic_form .insight').typeahead({
   name: 'insight',
   source: substringMatcher(insight)
 });
-
-
-

--- a/static/script.js
+++ b/static/script.js
@@ -161,12 +161,16 @@ function brushended() {
       .call(brush.extent(extent1))
       .call(brush.event);
 
-	var extent2 = (extent1.map(function (d) {return Math.floor(timeFormat(d)/7)+1}));
+	var extent2 = (extent1.map(function (d) {return Math.floor(timeFormat(d)/7)}));
 
 	updateMarkersBySlider(extent2[0]);
 
 	console.log(extent2)
 }
+
+$(window).on('resize', function(){
+	makeSlider();
+})
 
 var semanticActive = false; //toggle to active semantic UI walkthrough
 

--- a/static/script.js
+++ b/static/script.js
@@ -126,13 +126,14 @@ function makeSlider(){
 
 	svg_slider.append("g")
 	    .attr("class", "x axis")
-			.on("click", function(){svg_slider.select(".brush").call(brush.extent([timeFormat.parse('0'), timeFormat.parse('364')])); extent2 = [0,52]; console.log(extent2);	updateMarkersBySlider(extent2[0]);})
+			.on("click", function(){
+				svg_slider.select(".brush").transition().call(brush.extent([timeFormat.parse('0'), timeFormat.parse('364')])); extent2 = [0,52]; console.log(extent2);	updateMarkersBySlider(extent2[0]);})
 	    .attr("transform", "translate(0," + height + ")")
 	    .call(d3.svg.axis()
 	      .scale(x)
 	      .orient("bottom")
 	      .ticks(d3.time.months)
-				.tickFormat(d3.time.format("%B"))
+				.tickFormat(d3.time.format("%b"))
 	      .tickPadding(0))
 		  .selectAll("text")
 		    .attr("x", 6)

--- a/static/style.css
+++ b/static/style.css
@@ -93,7 +93,7 @@ em{
 .axis path,
 .axis line {
   fill: none;
-  stroke: #000;
+  stroke: none;
   shape-rendering: crispEdges;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -90,10 +90,7 @@ em{
   font: 11px sans-serif;
 }
 
-.axis path {
-  display: none;
-}
-
+.axis path,
 .axis line {
   fill: none;
   stroke: #000;
@@ -124,4 +121,3 @@ em{
 head.tt-dropdown-menu {
      display: none !important;
 }
-


### PR DESCRIPTION
Clicking on the slider tick marks/labels  now resets slider to extents,
markers adjust accordingly.

There’s a weird issue where if you then click on the brush’s selected
area, the markers readjust but the slider does not.
